### PR TITLE
Allow overriding publication contentType

### DIFF
--- a/lib/amqp/Publication.js
+++ b/lib/amqp/Publication.js
@@ -26,7 +26,7 @@ function Publication(getChannelFn, publishFn, vhost, config) {
     this.publish = function(payload, overrides, next) {
         var publishConfig = _.defaultsDeep(overrides, config)
         var content = getContent(payload, publishConfig)
-        publishConfig.options.contentType = content.type
+        publishConfig.options.contentType = publishConfig.options.contentType || content.type
         publishConfig.options.messageId = publishConfig.options.messageId || uuid()
 
         _publish(content.buffer, publishConfig, next)

--- a/tests/publications.tests.js
+++ b/tests/publications.tests.js
@@ -210,6 +210,31 @@ describe('Publications', function() {
         })
     })
 
+    it('should publish messages with custom contentType to normal exchanges', function(done) {
+        createBroker({
+            vhosts: vhosts,
+            publications: {
+                p1: {
+                    exchange: 'e1'
+                }
+            }
+        }, function(err, broker) {
+            assert.ifError(err)
+            broker.publish('p1', { message: 'test message' }, { options: { contentType: 'application/vnd+custom.contentType.v1' } }, function(err, publication) {
+                assert.ifError(err)
+                publication.on('success', function(messageId) {
+                    amqputils.getMessage('q1', namespace, function(err, message) {
+                        assert.ifError(err)
+                        assert.ok(message, 'Message was not present')
+                        assert.equal(message.properties.contentType, 'application/vnd+custom.contentType.v1')
+                        assert.equal(message.content.toString(), JSON.stringify({ message: 'test message' }))
+                        done()
+                    })
+                })
+            })
+        })
+    })
+
     it('should publish buffer messages to normal exchanges', function(done) {
         createBroker({
             vhosts: vhosts,


### PR DESCRIPTION
Sometimes you need a custom content type if that's expected by the consumer of you published messages. 

With this change `options.contentType` can be specified and it overrides the content type auto-detected by `rascal`.