### PR TITLE
Fix typo in bindExchange signature

### DIFF
--- a/lib/amqp/tasks/applyBindings.js
+++ b/lib/amqp/tasks/applyBindings.js
@@ -29,7 +29,7 @@ function bindQueue(config, channel, binding, next) {
     channel.bindQueue(destination.fullyQualifiedName, source.fullyQualifiedName, binding.bindingKey, binding.options, next)
 }
 
-function bindExchange(config, channel, name, next) {
+function bindExchange(config, channel, binding, next) {
     var destination = config.exchanges[binding.destination]
     if (!destination) return next(new Error(format('Unknown destination: %s', binding.destination)))
 

--- a/tests/vhost.tests.js
+++ b/tests/vhost.tests.js
@@ -118,6 +118,9 @@ describe('Vhost', function() {
                     exchanges: {
                         e1: {
                             assert: true
+                        },
+                        e2: {
+                            assert: true
                         }
                     },
                     queues: {
@@ -127,6 +130,11 @@ describe('Vhost', function() {
                     },
                     bindings: {
                         b1: {
+                            source: 'e1',
+                            destination: 'e2',
+                            destinationType: 'exchange'
+                        },
+                        b2: {
                             source: 'e1',
                             destination: 'q1'
                         }


### PR DESCRIPTION
There was a wrong parameter name in `applyBindings.js` preventing exchange bindings from being applied.