### PR TITLE
vhost emits connect and disconnect events

### DIFF
--- a/lib/amqp/Vhost.js
+++ b/lib/amqp/Vhost.js
@@ -29,6 +29,7 @@ function Vhost(config) {
         channelAllocator.pause()
         init(config, {}, function(err, config, ctx) {
             if (err) return next(err)
+            self.emit('connect')
             // TODO its possible a connection error has already triggered an init cycle, so may need to disconnect again
             ctx.connection.removeAllListeners('error')
             ctx.connection.once('error', handleConnectionError.bind(null, config))
@@ -99,6 +100,7 @@ function Vhost(config) {
 
     function handleConnectionError(config, err) {
         debug(format('Handling connection error: %s from %s', err.message, config.connection.loggableUrl))
+        self.emit('disconnect')
         channelAllocator.pause()
         connection = undefined
         self.emit('error', err)


### PR DESCRIPTION
As the user of a broker, I want to know when I get connected and disconnected.
With this PR, a Vhost now emits `connect` and `disconnect` events, that get forwarded to the broker object.