### PR TITLE
Wait for on message before consuming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 ### Updated
-- Connection failure error message
+- Improved connection failure error message
+- It is possible to go async between broker.subscribe and subscription.on('message'). This unlocks the possibility of promise support.
 
 ## 3.2.3
 ### Updated

--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ broker.subscribe('s1', function(err, subscription) {
 ```
 It's **very** important that you handle errors emitted by the subscriber. If not an underlying channel error will bubble up to the uncaught error handler and crash your node process.
 
-It's also **very** important not to go async between getting the subscription and listening for the message or error events. If you do, you risk leaking messages and not handling errors.
+Prior to Rascal 4.0.0 it was also **very** important not to go async between getting the subscription and listening for the message or error events. If you do, you risk leaking messages and not handling errors.
 
 Rascal supports text, buffers and anything it can JSON.parse, providing the contentType message property is set correctly. Text messages should be set to "text/plain" and JSON messages to "application/json". Other content types will be returned as a Buffer. If the publisher doesn't set the contentType or you want to override it you can do so in the subscriber configuration.
 ```json

--- a/lib/amqp/SubscriberSession.js
+++ b/lib/amqp/SubscriberSession.js
@@ -7,24 +7,31 @@ module.exports = SubscriberSession;
 
 inherits(SubscriberSession, EventEmitter);
 
-function SubscriberSession(options) {
+function SubscriberSession(sequentialChannelOperations, options) {
 
   var index = 0;
   var channels = {};
   var self = this;
 
   this.open = function(channel, consumerTag) {
+    debug('Opening subscriber session: %s on channel: %s', consumerTag, channel._rascal_id);
     channels[consumerTag] = { index: index++, channel: channel, consumerTag: consumerTag };
     channel.once('close', unref.bind(null, consumerTag));
     channel.once('error', unref.bind(null, consumerTag));
   };
 
   this.close = this.cancel = function(next) {
-    withCurrentChannel(function(channel, consumerTag) {
-      channel.cancel(consumerTag, function(err) {
-        if (err) return next(err);
-        doom(consumerTag);
-        next();
+    sequentialChannelOperations.push(function(done) {
+      withCurrentChannel(function(channel, consumerTag) {
+        debug('Cancelling subscription session: %s on channel: %s', consumerTag, channel._rascal_id);
+        channel.cancel(consumerTag, function(err) {
+          if (err) return next(err);
+          doom(consumerTag);
+          done();
+        });
+      }, function() {
+        debug('No current subscriber session');
+        done();
       });
     }, next);
   };

--- a/lib/amqp/Subscription.js
+++ b/lib/amqp/Subscription.js
@@ -6,6 +6,7 @@ var SubscriberError = require('./SubscriberError');
 var format = require('util').format;
 var backoff = require('../backoff');
 var crypto = require('crypto');
+var async = require('async');
 
 module.exports = {
   create: function(broker, vhost, counter, config, next) {
@@ -16,6 +17,9 @@ module.exports = {
 function Subscription(broker, vhost, config, counter) {
   var timer = backoff(config.retry);
   var subscriberError = new SubscriberError(broker, vhost);
+  var sequentialChannelOperations = async.queue(function(task, next) {
+    task(next);
+  }, 1);
   var self = this;
 
   this.init = function(next) {
@@ -24,10 +28,24 @@ function Subscription(broker, vhost, config, counter) {
   };
 
   this.subscribe = function(overrides, next) {
-    _subscribe(new SubscriberSession(config), _.defaultsDeep(overrides, config), next);
+    var session = new SubscriberSession(sequentialChannelOperations, config);
+    subscribeLater(session, _.defaultsDeep(overrides, config));
+    return next(null, session);
   };
 
-  function _subscribe(session, config, next) {
+  function subscribeLater(session, config) {
+    session.on('newListener', function(event) {
+      if (event !== 'message') return;
+      sequentialChannelOperations.push(function(done) {
+        subscribeNow(session, config, function(err) {
+          if (err) session.emit('error', err);
+          done();
+        });
+      });
+    });
+  }
+
+  function subscribeNow(session, config, next) {
     debug('Subscribing to queue: %s', config.queue);
     vhost.getChannel(function(err, channel) {
       if (err) return next(err);
@@ -206,7 +224,7 @@ function Subscription(broker, vhost, config, counter) {
     debug('Handling channel error: %s from %s using channel: %s', err.message, config.name, borked._rascal_id);
     removeErrorHandlers();
     session.emit('error', err);
-    config.retry && _subscribe(session, config, function(err) {
+    config.retry && subscribeNow(session, config, function(err) {
       if (!err) return;
       var delay = timer.next();
       debug('Will attempt resubscription in in %dms', delay);

--- a/test/subscriptions.tests.js
+++ b/test/subscriptions.tests.js
@@ -177,6 +177,29 @@ describe('Subscriptions', function() {
     });
   });
 
+  it('should not consume messages before a listener is bound', function(done) {
+    createBroker({
+      vhosts: vhosts,
+      publications: publications,
+      subscriptions: subscriptions,
+    }, function(err, broker) {
+      assert.ifError(err);
+      broker.publish('p1', 'test message', function(err) {
+        assert.ifError(err);
+        broker.subscribe('s1', function(err, subscription) {
+          assert.ifError(err);
+          setTimeout(function() {
+            subscription.on('message', function(message, content, ackOrNack) {
+              assert(message);
+              assert.equal(content, 'test message');
+              done();
+            });
+          }, 500);
+        });
+      });
+    });
+  });
+
   it('should consume to text/other messages', function(done) {
 
     createBroker({
@@ -275,7 +298,7 @@ describe('Subscriptions', function() {
     });
   });
 
-  it('should consume to invalid messages when no listener is bound', function(done) {
+  it('should not consume invalid messages when no invalid content/message listener is bound', function(done) {
     createBroker({
       vhosts: vhosts,
       publications: publications,
@@ -286,7 +309,9 @@ describe('Subscriptions', function() {
         assert.ifError(err);
         broker.subscribe('s1', function(err, subscription) {
           assert.ifError(err);
-          subscription.on('error', function() {
+          subscription.on('message', function() {
+            assert.ok(false, 'Message should not have been delivered');
+          }).on('error', function() {
             broker.shutdown(function(err) {
               assert.ifError(err);
               amqputils.assertMessageAbsent('q1', namespace, done);
@@ -308,7 +333,9 @@ describe('Subscriptions', function() {
         assert.ifError(err);
         broker.subscribe('s1', function(err, subscription) {
           assert.ifError(err);
-          subscription.on('invalid_content', function(err, message, ackOrNack) {
+          subscription.on('message', function() {
+            assert.ok(false, 'Message should not have been delivered');
+          }).on('invalid_content', function(err, message, ackOrNack) {
             assert(err);
             broker.shutdown(function(err) {
               assert.ifError(err);
@@ -331,7 +358,9 @@ describe('Subscriptions', function() {
         assert.ifError(err);
         broker.subscribe('s1', function(err, subscription) {
           assert.ifError(err);
-          subscription.on('invalid_message', function(err, message, ackOrNack) {
+          subscription.on('message', function() {
+            assert.ok(false, 'Message should not have been delivered');
+          }).on('invalid_message', function(err, message, ackOrNack) {
             assert(err);
             broker.shutdown(function(err) {
               assert.ifError(err);
@@ -354,7 +383,9 @@ describe('Subscriptions', function() {
         assert.ifError(err);
         broker.subscribe('s1', function(err, subscription) {
           assert.ifError(err);
-          subscription.on('invalid_content', function(err, message, ackOrNack) {
+          subscription.on('message', function() {
+            assert.ok(false, 'Message should not have been delivered');
+          }).on('invalid_content', function(err, message, ackOrNack) {
             assert(err);
             ackOrNack(function() {
               setTimeout(function() {
@@ -381,7 +412,9 @@ describe('Subscriptions', function() {
         assert.ifError(err);
         broker.subscribe('s1', function(err, subscription) {
           assert.ifError(err);
-          subscription.on('invalid_content', function(err, message, ackOrNack) {
+          subscription.on('message', function() {
+            assert.ok(false, 'Message should not have been delivered');
+          }).on('invalid_content', function(err, message, ackOrNack) {
             assert(err);
             ackOrNack(err, function() {
               setTimeout(function() {
@@ -774,7 +807,6 @@ describe('Subscriptions', function() {
   });
 
   it('should notify when redeliveries error is exceeded', function(done) {
-
     createBroker({
       vhosts: vhosts,
       publications: publications,
@@ -1788,7 +1820,9 @@ describe('Subscriptions', function() {
         assert.ifError(err);
         broker.subscribe('s1', function(err, subscription) {
           assert.ifError(err);
-          subscription.on('invalid_content', function(err, message, ackOrNack) {
+          subscription.on('message', function() {
+            assert.ok(false, 'Message should not have been delivered');
+          }).on('invalid_content', function(err, message, ackOrNack) {
             assert.equal(err.message, 'Unknown encryption profile: not-well-known');
             done();
           });
@@ -1830,7 +1864,9 @@ describe('Subscriptions', function() {
         assert.ifError(err);
         broker.subscribe('s1', function(err, subscription) {
           assert.ifError(err);
-          subscription.on('invalid_content', function(err, message, ackOrNack) {
+          subscription.on('message', function() {
+            assert.ok(false, 'Message should not have been delivered');
+          }).on('invalid_content', function(err, message, ackOrNack) {
             assert.equal(err.message, 'Invalid key length');
             done();
           });


### PR DESCRIPTION
With the current version of Rascal going asynchronous between subscribing and registering a message listener could result in message loss, e.g.

```js
broker.subscribe('s1', function(err, subscription) {
 setImmediate(function() {
   // The messages may be consumed before the handler is registered
   subscription.on('message', function(message, content, ackOrNack) {
    // What no message?
   })
 })
})
```
This has prevented promisifying the Rascal API and is therefore a blocker for async await.

This PR fixes the problem by only consuming from the channel after the message listener is registered on the subscription. However it wasn't quite this straightforward.

With asynchronous support, it was possible to cancel a subscription before it was actually established, which didn't actually cancel the subscription at all. I've fixed this by queueing sensitive channel operations, to sure they happen in the executed order