### PR TITLE
Fix README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,7 +617,7 @@ broker.publish("p1", "some message", { routingKey: "some.routing.key", options: 
 
 ```js
 await broker.publish("p1", "some message")
-await broker.publish("p1", "some message")
+await broker.publish("p1", "some message", "some.routing.key")
 await broker.publish("p1", "some message", { routingKey: "some.routing.key", options: { messageId: "foo", "expiration": 5000 } })
 ```
 


### PR DESCRIPTION
Fix example about promised broker.publish with routing key (routing key was missing) inside README file