### PR TITLE
Add support for default exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,21 +671,11 @@ Refer to the [amqplib](http://www.squaremobius.net/amqp.node/doc/channel_api.htm
 ```
 
 #### Publishing to a queue via the default exchange
-If you would like to publish directly to a queue, but you don't know the queue name ahead of time, you can use the fact that [all queues are automatically bound to the default exchange](https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default) with the routing key which is the same as the queue name. The default exchange's name is the empty string.
-```json
-{
-  "publications": {
-    "p1": {
-      "exchange": ""
-    }
-  },
-  "queues": ["q1"],
-  ...
-}
+If you would like to publish directly to a queue, but you don't know the queue name ahead of time, you can use the fact that [all queues are automatically bound to the default exchange](https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default) with the routing key which is the same as the queue name.
+
+You can publish directly to the queue:
 ```
-You can then publish to the queue:
-```
-broker.publish('p1', 'content', 'q1', function(err, publication) { ... });
+broker.publish('/', 'content', 'q1', function(err, publication) { ... });
 ```
 
 See the "default-exchange" in the examples directory for a full working example.

--- a/README.md
+++ b/README.md
@@ -670,6 +670,26 @@ Refer to the [amqplib](http://www.squaremobius.net/amqp.node/doc/channel_api.htm
 }
 ```
 
+#### Publishing to a queue via the default exchange
+If you would like to publish directly to a queue, but you don't know the queue name ahead of time, you can use the fact that [all queues are automatically bound to the default exchange](https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default) with the routing key which is the same as the queue name. The default exchange's name is the empty string.
+```json
+{
+  "publications": {
+    "p1": {
+      "exchange": ""
+    }
+  },
+  "queues": ["q1"],
+  ...
+}
+```
+You can then publish to the queue:
+```
+broker.publish('p1', 'content', 'q1', function(err, publication) { ... });
+```
+
+See the "default-exchange" in the examples directory for a full working example.
+
 #### Encrypting messages
 Rascal can be configured to automatically encrypt outbound messages.
 ```json

--- a/examples/default-exchange/config.js
+++ b/examples/default-exchange/config.js
@@ -1,0 +1,24 @@
+module.exports = {
+    vhosts: {
+        "/": {
+            connection: {
+                heartbeat: 1,
+                socketOptions: {
+                    timeout: 1000
+                }
+            },
+            exchanges: [""],
+            queues: ["demo_q"],
+            publications: {
+                "demo_pub": {
+                    "exchange": ""
+                }
+            },
+            subscriptions: {
+                "demo_sub": {
+                    "queue": "demo_q"
+                }
+            }
+        }
+    }
+}

--- a/examples/default-exchange/index.js
+++ b/examples/default-exchange/index.js
@@ -1,0 +1,21 @@
+var Rascal = require('../..')
+var config = require('./config')
+
+Rascal.Broker.create(Rascal.withDefaultConfig(config), function(err, broker) {
+  if (err) throw err
+
+  broker.subscribe('demo_sub', function(err, subscription) {
+    if (err) throw err
+    subscription.on('message', function(message, content, ackOrNack) {
+      console.log(content)
+      ackOrNack()
+    }).on('error', console.error)
+  }).on('error', console.error)
+
+  setInterval(function() {
+    broker.publish('demo_pub', new Date().toISOString() + ': hello world', "demo_q", function(err, publication) {
+      if (err) throw err
+      publication.on('error', console.error)
+    })
+  }, 1000)
+})

--- a/lib/amqp/Publication.js
+++ b/lib/amqp/Publication.js
@@ -12,8 +12,8 @@ module.exports = {
     var borrowChannel = vhost.borrowChannel.bind(vhost);
     var returnChannel = vhost.returnChannel.bind(vhost);
 
-    if (config.exchange && config.confirm) return new Publication(borrowConfirmChannel, returnConfirmChannel, publishToConfirmExchange, config).init(next);
-    if (config.exchange) return new Publication(borrowChannel, returnChannel, publishToExchange, config).init(next);
+    if (config.hasOwnProperty('exchange') && config.confirm) return new Publication(borrowConfirmChannel, returnConfirmChannel, publishToConfirmExchange, config).init(next);
+    if (config.hasOwnProperty('exchange')) return new Publication(borrowChannel, returnChannel, publishToExchange, config).init(next);
     if (config.queue && config.confirm) return new Publication(borrowConfirmChannel, returnConfirmChannel, sendToConfirmQueue, config).init(next);
     if (config.queue) return new Publication(borrowChannel, returnChannel, sendToQueue, config).init(next);
   },

--- a/lib/amqp/tasks/assertExchanges.js
+++ b/lib/amqp/tasks/assertExchanges.js
@@ -12,6 +12,12 @@ module.exports = _.curry(function(config, ctx, next) {
 
 function assertExchange(channel, config, next) {
   if (!config.assert) return next();
+
+  if (config.fullyQualifiedName === "") {
+    debug('Skipping assertion of default exchange');
+    return next();
+  }
+
   debug('Asserting exchange: %s', config.fullyQualifiedName);
   channel.assertExchange(config.fullyQualifiedName, config.type, config.options, next);
 }

--- a/lib/amqp/tasks/assertExchanges.js
+++ b/lib/amqp/tasks/assertExchanges.js
@@ -12,12 +12,7 @@ module.exports = _.curry(function(config, ctx, next) {
 
 function assertExchange(channel, config, next) {
   if (!config.assert) return next();
-
-  if (config.fullyQualifiedName === "") {
-    debug('Skipping assertion of default exchange');
-    return next();
-  }
-
+  if (config.fullyQualifiedName === '') return next();
   debug('Asserting exchange: %s', config.fullyQualifiedName);
   channel.assertExchange(config.fullyQualifiedName, config.type, config.options, next);
 }

--- a/lib/amqp/tasks/deleteExchanges.js
+++ b/lib/amqp/tasks/deleteExchanges.js
@@ -11,6 +11,7 @@ module.exports = _.curry(function(config, ctx, next) {
 });
 
 function deleteExchange(channel, config, next) {
+  if (config.fullyQualifiedName === '') return next();
   debug('Deleting exchange: %s', config.fullyQualifiedName);
   channel.deleteExchange(config.fullyQualifiedName, {}, next);
 }

--- a/lib/config/configure.js
+++ b/lib/config/configure.js
@@ -115,7 +115,7 @@ module.exports = _.curry(function(rascalConfig, next) {
     if (rascalConfig.publications[name] && rascalConfig.publications[name].vhost !== publicationConfig.vhost) throw new Error(format('Duplicate publication: %s', name));
     rascalConfig.publications[name] = _.defaultsDeep(publicationConfig, { name: name }, rascalConfig.defaults.publications);
     if (!rascalConfig.vhosts[publicationConfig.vhost]) return;
-    var destination = publicationConfig.exchange
+    var destination = publicationConfig.hasOwnProperty('exchange')
       ? rascalConfig.vhosts[publicationConfig.vhost].exchanges[publicationConfig.exchange]
       : rascalConfig.vhosts[publicationConfig.vhost].queues[publicationConfig.queue];
     rascalConfig.publications[name].destination = destination.fullyQualifiedName;

--- a/lib/config/configure.js
+++ b/lib/config/configure.js
@@ -184,7 +184,8 @@ module.exports = _.curry(function(rascalConfig, next) {
   }
 
   function configureExchanges(config) {
-    config.exchanges = ensureKeyedCollection(config.exchanges);
+    var defaultExchange = { '': {} };
+    config.exchanges = _.defaultsDeep(ensureKeyedCollection(config.exchanges), defaultExchange);
     _.each(config.exchanges, function(exchangeConfig, name) {
       debug('Configuring exchange: %s', name);
       config.exchanges[name] = _.defaultsDeep(exchangeConfig, { name: name, fullyQualifiedName: fqn.qualify(name, config.namespace) }, config.defaults.exchanges);

--- a/lib/config/fqn.js
+++ b/lib/config/fqn.js
@@ -5,6 +5,7 @@ module.exports = {
 };
 
 function qualify(name, namespace, unique) {
+  if (name === '') return name;
   name = prefix(namespace, name);
   name = suffix(unique ? unique : undefined, name);
   return name;

--- a/lib/config/validate.js
+++ b/lib/config/validate.js
@@ -101,13 +101,13 @@ module.exports = _.curry(function(config, next) {
   function validatePublication(publication, publicationName) {
     validateAttributes('Publication', publication, publicationName, ['name', 'vhost', 'exchange', 'queue', 'routingKey', 'confirm', 'options', 'destination', 'autoCreated', 'deprecated', 'encryption']);
     if (!publication.vhost) throw new Error(format('Publication: %s is missing a vhost', publicationName));
-    if (!(publication.exchange || publication.queue)) throw new Error(format('Publication: %s is missing an exchange or a queue', publicationName));
-    if ((publication.exchange && publication.queue)) throw new Error(format('Publication: %s has an exchange and a queue', publicationName));
+    if (!(publication.hasOwnProperty('exchange') || publication.queue)) throw new Error(format('Publication: %s is missing an exchange or a queue', publicationName));
+    if ((publication.hasOwnProperty('exchange') && publication.queue)) throw new Error(format('Publication: %s has an exchange and a queue', publicationName));
 
     if (!config.vhosts) throw new Error(format('Publication: %s refers to an unknown vhost: %s', publicationName, publication.vhost));
     if (!config.vhosts[publication.vhost]) throw new Error(format('Publication: %s refers to an unknown vhost: %s', publicationName, publication.vhost));
 
-    if (publication.exchange) {
+    if (publication.hasOwnProperty('exchange')) {
       if (!config.vhosts[publication.vhost].exchanges) throw new Error(format('Publication: %s refers to an unknown exchange: %s in vhost: %s', publicationName, publication.exchange, publication.vhost));
       if (!config.vhosts[publication.vhost].exchanges[publication.exchange]) throw new Error(format('Publication: %s refers to an unknown exchange: %s in vhost: %s', publicationName, publication.exchange, publication.vhost));
     } else {

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -342,6 +342,51 @@ describe('Configuration', function() {
         });
       });
 
+      it('should add default exchange by default', function() {
+        configure({
+          vhosts: {
+            v1: {
+              exchanges: {
+                e1: {
+                  assert: false,
+                  type: 'direct',
+                  options: {
+                    durable: false,
+                  },
+                },
+              },
+            },
+          },
+        }, function(err, config) {
+          assert.ifError(err);
+          assert.equal(config.vhosts.v1.exchanges[''].name, '');
+        });
+      });
+
+      it('should not overwrite existing default exchange', function() {
+        configure({
+          vhosts: {
+            v1: {
+              exchanges: {
+                '': {
+                  type: 'not-overwritten',
+                },
+                e1: {
+                  assert: false,
+                  type: 'direct',
+                  options: {
+                    durable: false,
+                  },
+                },
+              },
+            },
+          },
+        }, function(err, config) {
+          assert.ifError(err);
+          assert.equal(config.vhosts.v1.exchanges[''].type, 'not-overwritten');
+        });
+      });
+
       it('should inflate exchanges with empty structure', function() {
         configure({
           vhosts: {

--- a/test/publications.tests.js
+++ b/test/publications.tests.js
@@ -26,6 +26,7 @@ describe('Publications', function() {
       '/': {
         namespace: namespace,
         exchanges: {
+          '': {},
           e1: {
             assert: true,
           },
@@ -41,6 +42,9 @@ describe('Publications', function() {
             assert: true,
           },
           q2: {
+            assert: true,
+          },
+          q3: {
             assert: true,
           },
         },
@@ -161,6 +165,25 @@ describe('Publications', function() {
         assert.ifError(err);
         publication.on('success', function(messageId) {
           amqputils.assertMessage('q1', namespace, 'test message', done);
+        });
+      });
+    });
+  });
+
+  it('should publish text messages to queues via the default exchange', function(done) {
+    createBroker({
+      vhosts: vhosts,
+      publications: {
+        p1: {
+          exchange: '',
+        },
+      },
+    }, function(err, broker) {
+      assert.ifError(err);
+      broker.publish('p1', 'test message', broker.qualify('/', 'q3'), function(err, publication) {
+        assert.ifError(err);
+        publication.on('success', function(messageId) {
+          amqputils.assertMessage('q3', namespace, 'test message', done);
         });
       });
     });

--- a/test/publications.tests.js
+++ b/test/publications.tests.js
@@ -172,14 +172,9 @@ describe('Publications', function() {
   it('should publish text messages to queues via the default exchange', function(done) {
     createBroker({
       vhosts: vhosts,
-      publications: {
-        p1: {
-          exchange: '',
-        },
-      },
     }, function(err, broker) {
       assert.ifError(err);
-      broker.publish('p1', 'test message', broker.qualify('/', 'q3'), function(err, publication) {
+      broker.publish('/', 'test message', broker.qualify('/', 'q3'), function(err, publication) {
         assert.ifError(err);
         publication.on('success', function(messageId) {
           amqputils.assertMessage('q3', namespace, 'test message', done);

--- a/test/publications.tests.js
+++ b/test/publications.tests.js
@@ -26,7 +26,6 @@ describe('Publications', function() {
       '/': {
         namespace: namespace,
         exchanges: {
-          '': {},
           e1: {
             assert: true,
           },

--- a/test/validation.tests.js
+++ b/test/validation.tests.js
@@ -229,6 +229,21 @@ describe('Validation', function() {
       });
     });
 
+    it('should mandate either an exchange or a queue (c)', function() {
+      validate({
+        publications: {
+          p1: {
+            vhost: 'v1',
+            exchange: '', // default exchange
+            queue: 'q1',
+          },
+        },
+      }, function(err) {
+        assert.ok(err);
+        assert.equal('Publication: p1 has an exchange and a queue', err.message);
+      });
+    });
+
     it('should report unknown vhosts (a)', function() {
       validate({
         publications: {


### PR DESCRIPTION
- Specifically so that you can dynamically publish to a queue using the fact that the default exchange is bound to all queues by default

- There is an example that can be run, but there isn't a test/test-suite that ensures everything works as it should with the default exchange. @cressie176 - how best to test that the default exchange won't stop working in a regression situation? Add a new test file for default exchange or add the default exchange to a list of exchanges in an existing test somewhere?