### PR TITLE
Fix syntax for callbacks example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ const config = require('./config');
 const Broker = require('rascal').Broker;
 const config = require('./config');
 
-Broker.create(config), (err, broker) => {
+Broker.create(config, (err, broker) => {
   if (err) throw err;
 
   broker.on('error', console.error);


### PR DESCRIPTION
The usage example given in the README for using callbacks has an unmatched parenthesis. Removing it.