### PR TITLE
Handle channel back-pressure

### DIFF
--- a/lib/amqp/Publication.js
+++ b/lib/amqp/Publication.js
@@ -131,8 +131,11 @@ function removeListeners(channel, errorHandler, returnHandler) {
 
 function publishToExchange(channel, content, config, next) {
   debug('Publishing %d bytes to exchange: %s with routingKeys: %s', content.length, config.exchange, _.compact([].concat(config.routingKey, config.options.CC, config.options.BCC)).join(', '));
-  channel.publish(config.destination, config.routingKey, content, config.options);
-  next();
+  if(!channel.publish(config.destination, config.routingKey, content, config.options)) {
+    channel.once('drain', next);
+  } else {
+    next();
+  }
 }
 
 function publishToConfirmExchange(channel, content, config, next) {
@@ -142,8 +145,11 @@ function publishToConfirmExchange(channel, content, config, next) {
 
 function sendToQueue(channel, content, config, next) {
   debug('Publishing %d bytes to queue: %s', content.length, config.queue);
-  channel.sendToQueue(config.destination, content, config.options);
-  next();
+  if(!channel.sendToQueue(config.destination, content, config.options)) {
+    channel.once('drain', next);
+  } else {
+    next();
+  }
 }
 
 function sendToConfirmQueue(channel, content, config, next) {


### PR DESCRIPTION
As mentioned in [amqplib docs](http://www.squaremobius.net/amqp.node/channel_api.html#flowcontrol), channels mimic `stream.Writable` behaviour when being written to: a call to `publish` or `sendToQueue` can return `false`, which would mean that internal buffer has been filled and you should wait for `drain` event before sending more data.

Nodejs [docs for `stream.Writable`](https://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback) also strongly recommend respecting stream back-pressure to avoid memory issues (like clogging application memory with unsent data by continuously reading it from source stream).

This request implements it.

There are some points worth mentioning:
1. There are no changes for `ConfirmChannel`s because for them `next` will only be called after getting a response from broker which would imply that the data has been sent.
2. While this implementation mimics the example from nodejs docs, it implies that send operation will not finish (`next` will not be called) until the channel is drained. This makes sense because we want to make sure the data has been actually sent before calling it a success.
3. I haven't touched any tests and yet they are still green after this change. This kinda worries me, because the logic _has_ been changed. I didn't come up with a strait-forward way to cover this behaviour with tests.