### PR TITLE
Management: do not ignore specific credentials

### DIFF
--- a/lib/config/configure.js
+++ b/lib/config/configure.js
@@ -76,7 +76,9 @@ module.exports = _.curry(function(rascalConfig, next) {
 
   function configureManagementConnection(vhostConfig, vhostName, connection) {
     _.defaultsDeep(connection.management, { hostname: connection.hostname, auth: connection.auth });
-    connection.management.auth = connection.auth || connection.management.user + ':' + connection.management.password;
+    if (connection.management.user && connection.management.password) {
+      connection.management.auth = connection.management.user + ':' + connection.management.password;
+    }
     connection.management.url = connection.management.url || url.format(connection.management);
     connection.management.loggableUrl = connection.management.url.replace(/:[^:]*?@/, ':***@');
   }

--- a/test/config.tests.js
+++ b/test/config.tests.js
@@ -402,6 +402,72 @@ describe('Configuration', function() {
         });
       });
 
+      it('should configure the management connection from an object', function() {
+        configure({
+          vhosts: {
+            v1: {
+              connection: {
+                slashes: true,
+                protocol: 'protocol',
+                hostname: 'hostname',
+                port: 9000,
+                vhost: 'vhost',
+                user: 'user',
+                password: 'password',
+                management: {
+                  protocol: 'https',
+                  user: 'admin',
+                  password: 'adminpassword',
+                  port: 9999,
+                  options: {
+                    timeout: 555,
+                  },
+                },
+                options: {
+                  heartbeat: 10,
+                  channelMax: 100,
+                },
+              },
+            },
+          },
+        }, function(err, config) {
+          assert.ifError(err);
+          assert.equal(config.vhosts.v1.connections[0].management.url, 'https://admin:adminpassword@hostname:9999');
+        });
+      });
+
+      it('should configure the management connection with connection credentials', function() {
+        configure({
+          vhosts: {
+            v1: {
+              connection: {
+                slashes: true,
+                protocol: 'protocol',
+                hostname: 'hostname',
+                port: 9000,
+                vhost: 'vhost',
+                user: 'user',
+                password: 'password',
+                management: {
+                  protocol: 'https',
+                  port: 9999,
+                  options: {
+                    timeout: 444,
+                  },
+                },
+                options: {
+                  heartbeat: 10,
+                  channelMax: 100,
+                },
+              },
+            },
+          },
+        }, function(err, config) {
+          assert.ifError(err);
+          assert.equal(config.vhosts.v1.connections[0].management.url, 'https://user:password@hostname:9999');
+        });
+      });
+
       it('should generate a namespace when specified', function() {
         configure({
           vhosts: {


### PR DESCRIPTION
When configuring management with a different user than the connection, management credentials are ignored and regular ones are used, so check or assert cannot be performed.

It worked only if you specified `connection.management.url` directly, because `url.format` is bypassed.

(I've not tested the fix yet, just edited through github UI after reading the code)