### PR TITLE
emit error when publishFn err Channel closed

### DIFF
--- a/lib/amqp/Publication.js
+++ b/lib/amqp/Publication.js
@@ -96,6 +96,7 @@ function Publication(vhost, borrowChannelFn, returnChannelFn, publishFn, config)
         });
       } catch(err) {
         returnChannel(channel, errorHandler, returnHandler);
+        return emitter.emit('error', err, messageId);
       };
     });
 


### PR DESCRIPTION
when pool.acquire() success but connection is at error state (at same time network is broken), `Publication` try `publishFn` will throw err `IllegalOperationError {message: "Channel closed", stack: "IllegalOperationError: Channel closed\n    at Confi…", stackAtStateChange: "Stack capture: Socket error\n    at Connection.onSo…"}` and  be catched  , but not emit error event  for user to known this, it may lead to message loss !