### PR TITLE
Added a check for .unref(), to handle situations where it is not a function

### DIFF
--- a/lib/amqp/Broker.js
+++ b/lib/amqp/Broker.js
@@ -157,7 +157,9 @@ function Broker(config, components) {
     }, function(err) {
       if (err) return next(err);
       debug('Waiting %dms for all subscriber channels to close', timeout);
-      setTimeout(next, timeout).unref();
+      const t = setTimeout(next, timeout);
+      if(t.unref)
+        t.unref()
     });
   };
 

--- a/lib/amqp/SubscriberSession.js
+++ b/lib/amqp/SubscriberSession.js
@@ -59,7 +59,9 @@ function SubscriberSession(sequentialChannelOperations, config) {
   };
 
   this._schedule = function(fn, delay) {
-    timeout = setTimeout(fn, delay).unref();
+    timeout = setTimeout(fn, delay)
+    if(timeout.unref)
+      timeout = timeout.unref();
   };
 
   this._maxDeferCloseChannel = function(other) {
@@ -134,12 +136,14 @@ function SubscriberSession(sequentialChannelOperations, config) {
   */
   function scheduleClose(entry) {
     debug('Deferring close channel: %s by %dms', entry.channel._rascal_id, config.deferCloseChannel);
-    setTimeout(function() {
+    const t = setTimeout(function() {
       withConsumerChannel(entry.consumerTag, function(channel) {
         channel.close(function() {
           debug('Channel: %s was closed', channel._rascal_id);
         });
       });
-    }, config.deferCloseChannel).unref();
+    }, config.deferCloseChannel)
+    if(t.unref)
+      t.unref();
   }
 }

--- a/lib/amqp/Subscription.js
+++ b/lib/amqp/Subscription.js
@@ -160,7 +160,9 @@ function Subscription(broker, vhost, config, counter) {
     ackOrNack(session, message, err, function() {
       // Using setTimeout rather than process.nextTick as the latter fires before any IO.
       // If the app shuts down before the IO has completed, the message will be rolled back
-      setTimeout(session.emit.bind(session, 'error', err)).unref();
+      const t = setTimeout(session.emit.bind(session, 'error', err))
+      if(t.unref)
+        t.unref();
     });
   }
 

--- a/lib/amqp/Vhost.js
+++ b/lib/amqp/Vhost.js
@@ -366,7 +366,11 @@ function Vhost(config) {
       if (!err) return;
       var delay = timer.next();
       debug('Will attempt reconnection in in %dms', delay);
-      return setTimeout(handleConnectionError.bind(null, borked, config, err), delay).unref();
+      const t = setTimeout(handleConnectionError.bind(null, borked, config, err), delay);
+      if(t.unref) 
+        t.unref();
+
+      return t;
     });
   }
 }

--- a/test/subscriptions.tests.js
+++ b/test/subscriptions.tests.js
@@ -528,12 +528,14 @@ describe('Subscriptions', function() {
           subscription.on('message', function(message, content, ackOrNack) {
             assert.ok(message);
             ackOrNack();
-            setTimeout(function() {
+            const t = setTimeout(function() {
               broker.shutdown(function(err) {
                 assert.ifError(err);
                 amqputils.assertMessageAbsent('q1', namespace, done);
               });
-            }, 100).unref();
+            }, 100)
+            if(t.unref)
+              t.unref();
           });
         });
       });
@@ -555,12 +557,14 @@ describe('Subscriptions', function() {
           subscription.on('message', function(message, content, ackOrNack) {
             assert.ok(message);
             ackOrNack(new Error('reject'));
-            setTimeout(function() {
+            const t = setTimeout(function() {
               broker.shutdown(function(err) {
                 assert.ifError(err);
                 amqputils.assertMessageAbsent('q1', namespace, done);
               });
-            }, 100).unref();
+            }, 100)
+            if(t.unref)
+              t.unref();
           });
         });
       });

--- a/test/subscriptionsAsPromised.tests.js
+++ b/test/subscriptionsAsPromised.tests.js
@@ -475,11 +475,13 @@ describe('Subscriptions As Promised', function() {
           subscription.on('message', function(message, content, ackOrNack) {
             assert.ok(message);
             ackOrNack();
-            setTimeout(function() {
+            const t = setTimeout(function() {
               broker.shutdown().then(function() {
                 amqputils.assertMessageAbsent('q1', namespace, done);
               });
-            }, 100).unref();
+            }, 100)
+            if(t.unref)
+              t.unref();
           });
         });
       });
@@ -498,11 +500,13 @@ describe('Subscriptions As Promised', function() {
           subscription.on('message', function(message, content, ackOrNack) {
             assert.ok(message);
             ackOrNack(new Error('reject'));
-            setTimeout(function() {
+            const t = setTimeout(function() {
               broker.shutdown().then(function() {
                 amqputils.assertMessageAbsent('q1', namespace, done);
               });
-            }, 100).unref();
+            }, 100)
+            if(t.unref)
+              t.unref();
           });
         });
       });


### PR DESCRIPTION
In certain configs of Electron, on disconnect/reconnect, setTimeout(...).unref() "is not a function" due to Electron using the browser variant of setTimeout, which has no properties or return values, causing Electron/rascal to crash.

This adds a check to ensure .unref exists before calling it.