### PR TITLE
Exclude doomed channels

### DIFF
--- a/lib/amqp/SubscriberSession.js
+++ b/lib/amqp/SubscriberSession.js
@@ -102,7 +102,7 @@ function SubscriberSession(sequentialChannelOperations, config) {
   };
 
   function withCurrentChannel(fn, altFn) {
-    var entry = _.chain(channels).values().sortBy('index').last().value();
+    var entry = _.chain(channels).values().filter(channel => !channel.doomed).sortBy('index').last().value();
     if (entry) return fn(entry.channel, entry.consumerTag, entry);
     return altFn && altFn();
   }


### PR DESCRIPTION
## Purpose of PR
During debugging of one of our applications which kept getting "Channel closing..." errors in the after block in some acceptance tests, we noted some issue with subscription cancellation. Further investigation suggested that repeat subscription cancellation of the same subscription may be happening because of already doomed channels still being returned when the currentChannel is retrieved.

## This PR
- Filters out any doomed channels from being included in the available list of current channels.