### PR TITLE
Set acquireTimeoutMillis in default configuration

### DIFF
--- a/lib/config/baseline.js
+++ b/lib/config/baseline.js
@@ -10,6 +10,7 @@ module.exports = {
           idleTimeoutMillis: 60000,
           rejectionDelayMillis: 1000,
           testOnBorrow: true,
+          acquireTimeoutMillis: 15000,
         },
         confirmPool: {
           autostart: false,
@@ -19,6 +20,7 @@ module.exports = {
           idleTimeoutMillis: 60000,
           rejectionDelayMillis: 1000,
           testOnBorrow: true,
+          acquireTimeoutMillis: 15000,
         },
       },
       connectionStrategy: 'random',


### PR DESCRIPTION
By default a pool created by https://github.com/coopernurse/node-pool#createpool has infinite timeout when acquiring a resource from the pool. 

As rascal uses it to "manage" channels when it comes to publishing messages to RMQ, it can happen that calling to publish a message via rascal can stucks for ever. It was the case in https://github.com/guidesmiths/rascal/issues/156 and it was quite hard for me to figure out why my application hangs and where.

Note: configuring `publications.timeout` ([see here](https://github.com/guidesmiths/rascal#timeouts)) doesn't help because timeout starts ticking once you already have a channel acquired from the pool. 

Therefore, I suggest to set this timeout to 15 secs. In my eyes it is important to have timeout set to away waiting for ever  (it isn't so important whether it is 15s or 60s).  Having a timeout set allows an error to bubble up and reveal the issue.